### PR TITLE
Placement fix and lighting improvement

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -49,13 +49,7 @@ function UBCMap:calculateLighting(pos1, pos2)
         local pos1 = { x = blockpos.x * 16, y = blockpos.y * 16, z = blockpos.z * 16 }
         local pos2 = { x = blockpos.x * 16 + 15, y = blockpos.y * 16 + 15, z = blockpos.z * 16 + 15 }
 
-        local vm = minetest.get_voxel_manip()
-        local emin, emax = vm:read_from_map(pos1, pos2)
-        local a = VoxelArea:new {
-            MinEdge = emin,
-            MaxEdge = emax
-        }
-        vm:write_to_map(true)
+        minetest.fix_light(pos1, pos2)
 
         Debug.log("Finished calculating light for chunk: " .. context.loaded_blocks .. "/" .. context.total_blocks)
     end

--- a/init.lua
+++ b/init.lua
@@ -42,7 +42,6 @@ function UBCMap:calculateLighting(pos1, pos2)
         -- Increment number of blocks loaded
         context.loaded_blocks = context.loaded_blocks + 1
 
-
         if context.total_blocks == context.loaded_blocks then
             minetest.chat_send_all("Finished calculating light for the UBC map!")
         end
@@ -131,15 +130,13 @@ function UBCMap.place(startPosition, emergeLighting)
 
     UBCMap.storage:set_string("finishedGenerating", "true")
     UBCMap.storage:set_string("placementPos", "")
-    Debug.log("Emerging lighting")
-
-    local startPos = { x = startPosition.x, y = startPosition.y, z = startPosition.z }
-    local endPos = { x = startPosition.x + 2500, y = startPosition.y + 250, z = startPosition.z + 3500 }
-
     if (emergeLighting) then
+        Debug.log("Emerging lighting")
+        local startPos = { x = startPosition.x, y = startPosition.y, z = startPosition.z }
+        local endPos = { x = startPosition.x + 2500, y = startPosition.y + 250, z = startPosition.z + 3500 }
+
         UBCMap:calculateLighting(startPos, endPos)
     end
-
 
     Debug.log("Finished placing UBC Map!")
     minetest.chat_send_all("Finished generating!")

--- a/init.lua
+++ b/init.lua
@@ -66,7 +66,7 @@ function UBCMap:calculateLighting(pos1, pos2)
     minetest.emerge_area(pos1, pos2, emerge_callback, context)
 end
 
-function UBCMap.place(startPosition)
+function UBCMap.place(startPosition, emergeLighting)
     -- GC before we start placing the map
     collectgarbage("collect")
 
@@ -74,6 +74,10 @@ function UBCMap.place(startPosition)
         startPosition = { x = 0, y = -3, z = 0 }
     else
         startPosition = { x = startPosition.x, y = startPosition.y, z = startPosition.z }
+    end
+
+    if (emergeLighting == nil) then
+        emergeLighting = true
     end
 
     UBCMap.storage:set_string("finishedGenerating", "false")
@@ -132,7 +136,10 @@ function UBCMap.place(startPosition)
     local startPos = { x = startPosition.x, y = startPosition.y, z = startPosition.z }
     local endPos = { x = startPosition.x + 2500, y = startPosition.y + 250, z = startPosition.z + 3500 }
 
-    UBCMap:calculateLighting(startPos, endPos)
+    if (emergeLighting) then
+        UBCMap:calculateLighting(startPos, endPos)
+    end
+
 
     Debug.log("Finished placing UBC Map!")
     minetest.chat_send_all("Finished generating!")

--- a/init.lua
+++ b/init.lua
@@ -18,22 +18,57 @@ function UBCMap:placeSchematic(pos1, pos2, v, rotation, replacement, force_place
     minetest.chat_send_all("combined urban tile " .. tostring(v))
 
     --   if (mc_worldManager == nil) then
-    minetest.place_schematic_on_vmanip(vm, pos1, UBCMap.path .. "/schems/ubc_unbreakable_map_barrier_" .. tostring(v) .. ".mts", rotation, replacement, force_placement)
-    minetest.chat_send_all("combined unbreakable map barrier tile " .. tostring(v))
+    -- minetest.place_schematic_on_vmanip(vm, pos1, UBCMap.path .. "/schems/ubc_unbreakable_map_barrier_" .. tostring(v) .. ".mts", rotation, replacement, force_placement)
+    --minetest.chat_send_all("combined unbreakable map barrier tile " .. tostring(v))
     --  end
+
 
     -- The boolean parameter is whether or not we should update the lighting
     -- It causes a complete remesh; so I want to save this until the player loads into the area...
     vm:write_to_map(false)
 end
 
-function UBCMap.place(startPosition)
+function UBCMap:calculateLighting(pos1, pos2)
 
+    local function emerge_callback(blockpos, action,
+                                   num_calls_remaining, context)
+
+        -- On first call, record number of blocks
+        if not context.total_blocks then
+            context.total_blocks = num_calls_remaining + 1
+            context.loaded_blocks = 0
+        end
+
+        -- Increment number of blocks loaded
+        context.loaded_blocks = context.loaded_blocks + 1
+
+
+        if context.total_blocks == context.loaded_blocks then
+            minetest.chat_send_all("Finished calculating light for the UBC map!")
+        end
+
+        local pos1 = { x = blockpos.x * 16, y = blockpos.y * 16, z = blockpos.z * 16 }
+        local pos2 = { x = blockpos.x * 16 + 15, y = blockpos.y * 16 + 15, z = blockpos.z * 16 + 15 }
+
+        local vm = minetest.get_voxel_manip()
+        local emin, emax = vm:read_from_map(pos1, pos2)
+        local a = VoxelArea:new {
+            MinEdge = emin,
+            MaxEdge = emax
+        }
+        vm:write_to_map(true)
+
+        Debug.log("Finished calculating light for chunk: " .. context.loaded_blocks .. "/" .. context.total_blocks)
+    end
+
+    local context = {} -- persist data between callback calls
+    context.counter = 0
+    minetest.emerge_area(pos1, pos2, emerge_callback, context)
+end
+
+function UBCMap.place(startPosition)
     -- GC before we start placing the map
     collectgarbage("collect")
-
-    UBCMap.storage:set_string("finishedGenerating", "false")
-    UBCMap.storage:set_string("placementPos", minetest.serialize(startPosition))
 
     if (startPosition == nil) then
         startPosition = { x = 0, y = -3, z = 0 }
@@ -41,11 +76,14 @@ function UBCMap.place(startPosition)
         startPosition = { x = startPosition.x, y = startPosition.y, z = startPosition.z }
     end
 
+    UBCMap.storage:set_string("finishedGenerating", "false")
+    UBCMap.storage:set_string("placementPos", minetest.serialize(startPosition))
+
     local coords = {}
     for xx = 0, 2500, 500 do
-        for yy = 1, 7 do
-            y = 3500 - (yy * 500) + startPosition.y
-            table.insert(coords, { xx + startPosition.x, y + startPosition.z })
+        for zz = 1, 7 do
+            local z = 3500 - (zz * 500)
+            table.insert(coords, { xx + startPosition.x, z + startPosition.z })
         end
     end
 
@@ -61,7 +99,7 @@ function UBCMap.place(startPosition)
     if (startingValue <= 28) then
         for v = startingValue, 28 do
             --for _, v in pairs(tiles) do
-            coord = coords[v]
+            local coord = coords[v]
             -- y must always be -3 because the schematic pos starts here
             -- this maintains the true elevations across the map
             -- place terrain first
@@ -89,6 +127,13 @@ function UBCMap.place(startPosition)
 
     UBCMap.storage:set_string("finishedGenerating", "true")
     UBCMap.storage:set_string("placementPos", "")
+    Debug.log("Emerging lighting")
+
+    local startPos = { x = startPosition.x, y = startPosition.y, z = startPosition.z }
+    local endPos = { x = startPosition.x + 2500, y = startPosition.y + 250, z = startPosition.z + 3500 }
+
+    UBCMap:calculateLighting(startPos, endPos)
+
     Debug.log("Finished placing UBC Map!")
     minetest.chat_send_all("Finished generating!")
 

--- a/integration.lua
+++ b/integration.lua
@@ -7,6 +7,12 @@ if (mc_worldManager) then
         UBCMap.place(realm.StartPos)
     end
 else
+
+    Debug = {}
+    function Debug.log(message)
+        minetest.debug(message)
+    end
+
     -- We'll register this command if we're not using the realm system from MC_worldmanager so that the map can still be placed.
     -- If we are using the realm system, we don't want this command as it can and will interfere.
     minetest.register_chatcommand("mosaic_mts", {

--- a/integration.lua
+++ b/integration.lua
@@ -4,7 +4,7 @@ if (mc_worldManager) then
     --  mc_worldManager.spawnRealmSchematic = "ubc"
 
     function UBCMap.placeRealm(realm)
-        UBCMap.place(realm.StartPos)
+        UBCMap.place(realm.StartPos, false)
     end
 else
 

--- a/integration.lua
+++ b/integration.lua
@@ -4,7 +4,7 @@ if (mc_worldManager) then
     --  mc_worldManager.spawnRealmSchematic = "ubc"
 
     function UBCMap.placeRealm(realm)
-        UBCMap.place(realm.StartPos, false)
+        UBCMap.place(realm.StartPos, true)
     end
 else
 

--- a/map.conf
+++ b/map.conf
@@ -1,12 +1,12 @@
 author = pauldpickell
 name = UBC Campus
 format = procedural
-spawn_pos_x = 1250
-spawn_pos_y = 1750
-spawn_pos_z = 1250
+spawn_pos_x = 969
+spawn_pos_y = 89
+spawn_pos_z = 1561
 schematic_size_x = 2500
-schematic_size_y = 3500
-schematic_size_z = 2500
+schematic_size_y = 250
+schematic_size_z = 3500
 schematic_table_name = UBCMap
 realm_create_function_name = placeRealm
 license = GNU General Public License v3.0


### PR DESCRIPTION
This PR adds a fix for map placement being calculated incorrectly and adds an option to pre-calculate the lighting of the map after placing it (which, for certain machines like my laptop, seems to improve speeds; while on my desktop, is necessary for shadows). 

This PR also fixes the missing Debug.log() function when mc_classroom is not installed.

This PR also fixes incorrect realm spawn location in the realm template config file